### PR TITLE
Generate world

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ require:
 
 MessageSpies:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'db/schema.rb'

--- a/app/assets/stylesheets/grid.scss
+++ b/app/assets/stylesheets/grid.scss
@@ -3,6 +3,7 @@
     justify-content: center;
     align-items: center;
     grid-template-columns: repeat(6, 115px);
+    gap: 10px; /* Optional: Adds space between cells if needed */
 }
 
 .grid_row {
@@ -14,12 +15,11 @@
     height: 115px;
     border: 1px solid;
     position: relative;
-    overflow: hidden; /* or auto, scroll */
+    overflow: hidden; /* Ensures content doesn't overflow from the grid cell */
 }
 
 .empty_cell {
     background-color: #f0f0f0;
-
     &:hover {
         background-color: #c8c8c8;
         cursor: pointer;
@@ -38,10 +38,11 @@
 }
 
 .grid_image {
-    height: 100%
+    width: 100%;
+    height: 100%;
+    object-fit: cover; /* Ensures the image covers the cell without distortion */
 }
 
 .hidden {
-    //
     display: none;
 }

--- a/app/assets/stylesheets/grid.scss
+++ b/app/assets/stylesheets/grid.scss
@@ -42,6 +42,6 @@
 }
 
 .hidden {
-    // 
+    //
     display: none;
 }

--- a/app/assets/stylesheets/grid.scss
+++ b/app/assets/stylesheets/grid.scss
@@ -19,7 +19,7 @@
 }
 
 .empty_cell {
-    background-color: #f0f0f0;
+    background-color: white;
     &:hover {
         background-color: #c8c8c8;
         cursor: pointer;

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -21,12 +21,14 @@ class WorldsController < ApplicationController
     id = params[:id] # retrieve world ID from URI route
     @world = World.find(id)
     @world.init_if_not_inited
+    @world.load_images_from_s3
     @data = {}
     grid_arr = @world.gridsquares.to_ary
     grid_arr.each do |cell|
       @data[cell.row] ||= {}
       @data[cell.row][cell.col] = cell
     end
+    @data = @world.gridsquares
     @world.generate_cell(0, 0)
   end
 

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -27,7 +27,7 @@ class WorldsController < ApplicationController
       @data[cell.row] ||= {}
       @data[cell.row][cell.col] = cell
     end
-    # @world.enter_cell(0, 0)
+    @world.generate_cell(0, 0)
   end
 
   def index

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -29,7 +29,7 @@ class WorldsController < ApplicationController
       @data[cell.row][cell.col] = cell
     end
     @data = @world.gridsquares
-    @world.generate_cell(0, 0)
+    #@world.generate_cell(0, 0)
   end
 
   def index

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -29,7 +29,7 @@ class WorldsController < ApplicationController
       @data[cell.row][cell.col] = cell
     end
     @data = @world.gridsquares
-    #@world.generate_cell(0, 0)
+    #@world.generate_cell(5, 4)
   end
 
   def index

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -29,7 +29,7 @@ class WorldsController < ApplicationController
       @data[cell.row][cell.col] = cell
     end
     @data = @world.gridsquares
-    #@world.generate_cell(5, 4)
+    @world.generate_cell(3, 4)
   end
 
   def index

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -22,14 +22,17 @@ class WorldsController < ApplicationController
     @world = World.find(id)
     @world.init_if_not_inited
     @world.load_images_from_s3
-    @data = {}
-    grid_arr = @world.gridsquares.to_ary
-    grid_arr.each do |cell|
-      @data[cell.row] ||= {}
-      @data[cell.row][cell.col] = cell
+    @data = build_grid_data(@world.gridsquares)
+    @world.generate_cell(2, 4)
+  end
+
+  def build_grid_data(gridsquares)
+    data = {}
+    gridsquares.each do |cell|
+      data[cell.row] ||= {}
+      data[cell.row][cell.col] = cell
     end
-    @data = @world.gridsquares
-    @world.generate_cell(3, 4)
+    data
   end
 
   def index

--- a/app/models/world.rb
+++ b/app/models/world.rb
@@ -6,23 +6,8 @@ require 'net/http'
 require 'json'
 require 'aws-sdk-s3'
 
-# represents the model class for the worlds object
-class World < ApplicationRecord
-  has_many :gridsquares, dependent: :destroy
-  @@dim = 6 # rubocop:disable Style/ClassVars
-
-  # this must be done this way, active stroage DOES NOT WORK
-  # with after_create call back when seeding!!!!!!!
-  def init_if_not_inited
-    return unless gridsquares.empty?
-
-    initialize_grid
-  end
-
-  def self.dim
-    @@dim
-  end
-
+# Helper methods for the World model
+module WorldHelper
   def load_images_from_s3
     s3 = Aws::S3::Client.new(region: ENV['AWS_Region'])
     @gridsquares = gridsquares.all
@@ -33,23 +18,48 @@ class World < ApplicationRecord
     end
   end
 
-  def get_image_from_s3(s3, gridsquare)
+  def get_image_from_s3(s3_client, gridsquare)
     bucket_name = ENV['S3_BUCKET_NAME']
     key = "worlds/#{id}/grid_#{gridsquare.row}_#{gridsquare.col}.png"
 
     begin
-      # Check if the object exists in the bucket
-      s3.head_object(bucket: bucket_name, key: key)
-      # Return the public URL
+      s3_client.head_object(bucket: bucket_name, key: key)
       "https://#{bucket_name}.s3.amazonaws.com/#{key}"
     rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
       Rails.logger.warn("S3 object not found: bucket=#{bucket_name}, key=#{key}")
-      nil # No image found for the grid square
+      nil
     end
   end
+end
 
-  def generate_cell(_row, _col)
-    # Step 1: Generate text description
+# represents the model class for the worlds object
+class World < ApplicationRecord
+  include WorldHelper
+
+  has_many :gridsquares, dependent: :destroy
+  @@dim = 6 # rubocop:disable Style/ClassVars
+
+  def init_if_not_inited
+    return unless gridsquares.empty?
+
+    initialize_grid
+  end
+
+  def self.dim
+    @@dim
+  end
+
+  def generate_cell(row, col)
+    text = generate_text_description(row, col)
+    return unless text
+
+    image_uri = generate_image_ai(text)
+    return unless image_uri
+
+    download_and_attach_image(image_uri, row, col)
+  end
+
+  def generate_text_description(row, col)
     uri = URI('https://api.openai.com/v1/chat/completions')
     headers = { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{ENV['OPENAI_API_KEY']}" }
     body = {
@@ -57,53 +67,39 @@ class World < ApplicationRecord
       messages: [
         { role: 'system',
           content: 'Pick a random environment/biome/area that would make sense to be in an area in a video game. Return the environment as one word.' },
-        { role: 'user', content: "Player entered cell (#{_row}, #{_col})" }
+        { role: 'user', content: "Player entered cell (#{row}, #{col})" }
       ],
       max_tokens: 10
     }.to_json
 
+    response = make_http_request(uri, headers, body)
+    return unless response.code.to_i == 200
+
+    result = JSON.parse(response.body)
+    result.dig('choices', 0, 'message', 'content')&.strip
+  end
+
+  def make_http_request(uri, headers, body)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     request = Net::HTTP::Post.new(uri.path, headers)
     request.body = body
+    http.request(request)
+  end
 
-    response = http.request(request)
-    if response.code.to_i != 200
-      Rails.logger.debug "Call to OpenAI failed with status code #{response.code.to_i}: #{response.body}"
-      return
-    end
+  def download_and_attach_image(image_uri, row, col)
+    image_response = Net::HTTP.get_response(URI(image_uri))
+    return unless image_response.code.to_i == 200
 
-    result = JSON.parse(response.body)
-    if result['choices'] && result['choices'][0]
-      text = result['choices'][0]['message']['content'].strip
-      Rails.logger.debug("Generated text: #{text}")
+    new_image = {
+      io: StringIO.new(image_response.body),
+      filename: "#{row}_#{col}_generated.png",
+      content_type: 'image/png'
+    }
 
-      # Step 2: Generate image based on the text
-      image_uri = generate_image_ai(text)
-      Rails.logger.debug("Generated image URI: #{image_uri}")
-
-      # Step 3: Download the image
-      image_response = Net::HTTP.get_response(URI(image_uri))
-      if image_response.code.to_i == 200
-        new_image = {
-          io: StringIO.new(image_response.body),
-          filename: "#{_row}_#{_col}_generated.png",
-          content_type: 'image/png'
-        }
-
-        gridsquare = gridsquares.find_or_create_by(row: _row, col: _col)
-
-        # Purge existing image and attach new one to S3
-        gridsquare.image.purge if gridsquare.image.attached?
-        gridsquare.image.attach(new_image) # ActiveStorage handles the S3 upload
-
-        Rails.logger.debug "Image successfully updated for cell (#{_row}, #{_col})"
-      else
-        Rails.logger.debug "Failed to download the image: #{image_response.body}"
-      end
-    else
-      Rails.logger.debug "Unexpected response from OpenAI: #{response.body}"
-    end
+    gridsquare = gridsquares.find_or_create_by(row: row, col: col)
+    gridsquare.image.purge if gridsquare.image.attached?
+    gridsquare.image.attach(new_image)
   end
 
   def generate_image_ai(text)
@@ -118,28 +114,17 @@ class World < ApplicationRecord
       size: '256x256'
     }.to_json
 
-    http = Net::HTTP.new(dalle_uri.host, dalle_uri.port)
-    http.use_ssl = true
-    request = Net::HTTP::Post.new(dalle_uri.path, headers)
-    request.body = dalle_body
-
-    response = http.request(request)
-
-    raise "Call to OpenAI failed with status code #{response.code.to_i}: #{response.body}" if response.code.to_i != 200
+    response = make_http_request(dalle_uri, headers, dalle_body)
+    return unless response.code.to_i == 200
 
     result = JSON.parse(response.body)
-    raise "Unexpected response from OpenAI: #{response.body}" unless result['data'] && result['data'][0]
-
-    result['data'][0]['url']
+    result.dig('data', 0, 'url')
   end
 
   def initialize_grid
     (1..@@dim).each do |row|
       (1..@@dim).each do |col|
         gridsquares.create!(row: row, col: col)
-        # path = Rails.root.join('db/shreck.png')
-        # gridsquares.where(row: row, col: col).first.image.attach(io: File.open(path), filename: 'face.jpg',
-        #                                                          content_type: 'image/png')
       end
     end
   end

--- a/app/models/world.rb
+++ b/app/models/world.rb
@@ -57,7 +57,7 @@ class World < ApplicationRecord
     body = {
       model: 'gpt-3.5-turbo',
       messages: [
-        { role: 'system', content: 'Pick a random environment that would make sense to be in a video game. Return the environment as one word.' },
+        { role: 'system', content: 'Pick a random environment/biome/area that would make sense to be in an area in a video game. Return the environment as one word.' },
         { role: 'user', content: "Player entered cell (#{_row}, #{_col})" }
       ],
       max_tokens: 10

--- a/app/views/worlds/show.html.erb
+++ b/app/views/worlds/show.html.erb
@@ -1,38 +1,16 @@
-<!DOCTYPE html>
-<html lang="en-US">
-<head>
-  <title>Worlds</title>
-  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
-<div class="game_toolbar">
-  <%= button_to 'Back to Worlds', worlds_path, method: :get, id: "back_button", class: "secondary_button" %>
-  <span class="world_id">World ID: <%= @world[:world_code] %></span>
-  <span class="world_name">World Name: <%= @world[:world_name] %></span>
-</div>
+<% @world.gridsquares.each do |gridsquare| %>
+  <div class="cell">
+    <h3>Cell: (<%= gridsquare.row %>, <%= gridsquare.col %>)</h3>
 
-<%= yield %>
-
-<div class="grid_container">
-  <% (1..World.dim).each do |row| %>
-    <% (1..World.dim).each do |col| %>
-      <div class="grid_cell">
-        <% grid_square = @data[row][col] %>
-        <% if grid_square&.image&.attached? %>
-          <!-- Display the image if attached -->
-          <%= image_tag(url_for(grid_square.image), class: "grid_image") %>
-          <p>Image found for cell <%= row %>-<%= col %></p>
-        <% else %>
-          <!-- Debug output if no image -->
-          <p>No image attached for cell <%= row %>-<%= col %></p>
-        <% end %>
-        <div class="hidden"><%= row %>-<%= col %></div>
+    <% if gridsquare.image.attached? %>
+      <div class="image-container">
+        <%= image_tag rails_blob_path(gridsquare.image, only_path: true), alt: "Generated Image for Cell (#{gridsquare.row}, #{gridsquare.col})", class: "cell-image" %>
       </div>
+    <% else %>
+      <p>No image available</p>
     <% end %>
-  <% end %>
-</div>
 
-</body>
-</html>
+    <!-- Remove the description part if not needed -->
+    <p>No description available</p>
+  </div>
+<% end %>

--- a/app/views/worlds/show.html.erb
+++ b/app/views/worlds/show.html.erb
@@ -2,34 +2,37 @@
 <html lang="en-US">
 <head>
   <title>Worlds</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>
 <div class="game_toolbar">
-  <%= button_to 'Back to Worlds', worlds_path, method: :get, id: "back_button", class: "secondary_button"%>
+  <%= button_to 'Back to Worlds', worlds_path, method: :get, id: "back_button", class: "secondary_button" %>
   <span class="world_id">World ID: <%= @world[:world_code] %></span>
   <span class="world_name">World Name: <%= @world[:world_name] %></span>
 </div>
+
 <%= yield %>
 
 <div class="grid_container">
   <% (1..World.dim).each do |row| %>
     <% (1..World.dim).each do |col| %>
-      <% if row == 1 && col == 1 %>
-          <div class="grid_cell filled_cell" >
-            <%=image_tag(url_for(@data[row][col].image),class: "grid_image") %>
-            <div class="hidden"><%=row%>-<%=col%></div>
-          </div>
+      <div class="grid_cell">
+        <% grid_square = @data[row][col] %>
+        <% if grid_square&.image&.attached? %>
+          <!-- Display the image if attached -->
+          <%= image_tag(url_for(grid_square.image), class: "grid_image") %>
+          <p>Image found for cell <%= row %>-<%= col %></p>
         <% else %>
-          <div class="grid_cell filled_cell">
-          <%=image_tag(url_for(@data[row][col].image),class: "grid_image") %>
-          <div class="hidden"><%=row%>-<%=col%></div>
-          </div>
+          <!-- Debug output if no image -->
+          <p>No image attached for cell <%= row %>-<%= col %></p>
         <% end %>
+        <div class="hidden"><%= row %>-<%= col %></div>
+      </div>
     <% end %>
   <% end %>
 </div>
+
 </body>
 </html>

--- a/app/views/worlds/show.html.erb
+++ b/app/views/worlds/show.html.erb
@@ -16,17 +16,20 @@
 <%= yield %>
 
 <div class="grid_container">
-  <% @world.gridsquares.each do |gridsquare| %>
-    <div class="grid_cell <%= 'filled_cell' if gridsquare.image.attached? %>">
-      <% if gridsquare.image.attached? %>
-        <%= image_tag rails_blob_path(gridsquare.image, only_path: true), alt: "Generated Image for Cell (#{gridsquare.row}, #{gridsquare.col})", class: "grid_image" %>
-      <% else %>
-        <p>No image available</p>
-      <% end %>
-      <div class="hidden"><%= gridsquare.row %>-<%= gridsquare.col %></div>
-    </div>
+  <% max_rows = World.dim %> <!-- Adjust to your grid's total rows -->
+  <% max_cols = World.dim %> <!-- Adjust to your grid's total columns -->
+
+  <% (0...max_rows).each do |row| %>
+    <% (0...max_cols).each do |col| %>
+      <% gridsquare = @world.gridsquares.find { |gs| gs.row == row && gs.col == col } %>
+      <div class="grid_cell <%= 'filled_cell' if gridsquare&.image&.attached? %>"
+           style="grid-row: <%= row + 1 %>; grid-column: <%= col + 1 %>;">
+        <% if gridsquare&.image&.attached? %>
+          <%= image_tag rails_blob_path(gridsquare.image, only_path: true), alt: "Generated Image for Cell (#{row}, #{col})", class: "grid_image" %>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 </div>
-
 </body>
 </html>

--- a/app/views/worlds/show.html.erb
+++ b/app/views/worlds/show.html.erb
@@ -1,16 +1,32 @@
-<% @world.gridsquares.each do |gridsquare| %>
-  <div class="cell">
-    <h3>Cell: (<%= gridsquare.row %>, <%= gridsquare.col %>)</h3>
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <title>Worlds</title>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+<div class="game_toolbar">
+  <%= button_to 'Back to Worlds', worlds_path, method: :get, id: "back_button", class: "secondary_button"%>
+  <span class="world_id">World ID: <%= @world[:world_code] %></span>
+  <span class="world_name">World Name: <%= @world[:world_name] %></span>
+</div>
 
-    <% if gridsquare.image.attached? %>
-      <div class="image-container">
-        <%= image_tag rails_blob_path(gridsquare.image, only_path: true), alt: "Generated Image for Cell (#{gridsquare.row}, #{gridsquare.col})", class: "cell-image" %>
-      </div>
-    <% else %>
-      <p>No image available</p>
-    <% end %>
+<%= yield %>
 
-    <!-- Remove the description part if not needed -->
-    <p>No description available</p>
-  </div>
-<% end %>
+<div class="grid_container">
+  <% @world.gridsquares.each do |gridsquare| %>
+    <div class="grid_cell <%= 'filled_cell' if gridsquare.image.attached? %>">
+      <% if gridsquare.image.attached? %>
+        <%= image_tag rails_blob_path(gridsquare.image, only_path: true), alt: "Generated Image for Cell (#{gridsquare.row}, #{gridsquare.col})", class: "grid_image" %>
+      <% else %>
+        <p>No image available</p>
+      <% end %>
+      <div class="hidden"><%= gridsquare.row %>-<%= gridsquare.col %></div>
+    </div>
+  <% end %>
+</div>
+
+</body>
+</html>

--- a/db/migrate/20241126202131_add_image_url_to_gridsquares.rb
+++ b/db/migrate/20241126202131_add_image_url_to_gridsquares.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImageUrlToGridsquares < ActiveRecord::Migration[7.1]
+  def change
+    add_column :gridsquares, :image_url, :string
+  end
+end

--- a/db/migrate/20241126202131_add_image_url_to_gridsquares.rb
+++ b/db/migrate/20241126202131_add_image_url_to_gridsquares.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Adds image_url column to gridsquares table
 class AddImageUrlToGridsquares < ActiveRecord::Migration[7.1]
   def change
     add_column :gridsquares, :image_url, :string

--- a/db/migrate/20241126202132_add_timestamps_to_active_storage_variant_records.rb
+++ b/db/migrate/20241126202132_add_timestamps_to_active_storage_variant_records.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration adds timestamps to the active_storage_variant_records table
+class AddTimestampsToActiveStorageVariantRecords < ActiveRecord::Migration[7.1]
+  def change
+    change_table :active_storage_variant_records, bulk: true, &:timestamps
+  end
+end

--- a/db/migrate/20241126202133_create_active_storage_blobs.rb
+++ b/db/migrate/20241126202133_create_active_storage_blobs.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This migration creates the active storage blobs table
+class CreateActiveStorageBlobs < ActiveRecord::Migration[7.1]
+  def change
+    create_active_storage_blobs_table
+  end
+
+  private
+
+  def create_active_storage_blobs_table
+    create_table 'active_storage_blobs', force: :cascade do |t|
+      t.timestamps
+      add_columns_to_active_storage_blobs(t)
+      t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+    end
+  end
+
+  def add_columns_to_active_storage_blobs(table)
+    table.string 'key', null: false
+    table.string 'filename', null: false
+    table.string 'content_type'
+    table.text 'metadata'
+    table.string 'service_name', null: false
+    table.bigint 'byte_size', null: false
+    table.string 'checksum'
+    table.datetime 'created_at', null: false
+  end
+end

--- a/db/migrate/20241126202133_create_active_storage_blobs.rb
+++ b/db/migrate/20241126202133_create_active_storage_blobs.rb
@@ -1,3 +1,5 @@
+# db/migrate/20241126202133_create_active_storage_blobs.rb
+
 # frozen_string_literal: true
 
 # This migration creates the active storage blobs table
@@ -24,6 +26,5 @@ class CreateActiveStorageBlobs < ActiveRecord::Migration[7.1]
     table.string 'service_name', null: false
     table.bigint 'byte_size', null: false
     table.string 'checksum'
-    table.datetime 'created_at', null: false
   end
 end

--- a/db/migrate/20241126202134_create_active_storage_attachments.rb
+++ b/db/migrate/20241126202134_create_active_storage_attachments.rb
@@ -1,0 +1,18 @@
+# db/migrate/20241126202134_create_active_storage_attachments.rb
+
+# frozen_string_literal: true
+
+# This migration creates the active storage attachments table
+class CreateActiveStorageAttachments < ActiveRecord::Migration[7.1]
+  def change
+    create_table 'active_storage_attachments', force: :cascade do |t|
+      t.string 'name', null: false
+      t.string 'record_type', null: false
+      t.bigint 'record_id', null: false
+      t.bigint 'blob_id', null: false
+      t.datetime 'created_at', null: false
+      t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
+      t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
+    end
+  end
+end

--- a/db/migrate/20241126202135_create_active_storage_variant_records.rb
+++ b/db/migrate/20241126202135_create_active_storage_variant_records.rb
@@ -1,0 +1,16 @@
+# db/migrate/20241126202134_create_active_storage_variant_records.rb
+
+# frozen_string_literal: true
+
+# This migration creates the active storage variant records table
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table 'active_storage_variant_records', force: :cascade do |t|
+      t.bigint 'blob_id', null: false
+      t.string 'variation_digest', null: false
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,74 +12,75 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_26_202131) do
+ActiveRecord::Schema[7.1].define(version: 20_241_126_202_131) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  create_table 'active_storage_attachments', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'record_type', null: false
+    t.bigint 'record_id', null: false
+    t.bigint 'blob_id', null: false
+    t.datetime 'created_at', null: false
+    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
+    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
+                                                    unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum"
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  create_table 'active_storage_blobs', force: :cascade do |t|
+    t.string 'key', null: false
+    t.string 'filename', null: false
+    t.string 'content_type'
+    t.text 'metadata'
+    t.string 'service_name', null: false
+    t.bigint 'byte_size', null: false
+    t.string 'checksum'
+    t.datetime 'created_at', null: false
+    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  create_table 'active_storage_variant_records', force: :cascade do |t|
+    t.bigint 'blob_id', null: false
+    t.string 'variation_digest', null: false
+    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
   end
 
-  create_table "gridsquares", force: :cascade do |t|
-    t.bigint "world_id"
-    t.integer "row"
-    t.integer "col"
-    t.boolean "filled"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "image_url"
-    t.index ["world_id"], name: "index_gridsquares_on_world_id"
+  create_table 'gridsquares', force: :cascade do |t|
+    t.bigint 'world_id'
+    t.integer 'row'
+    t.integer 'col'
+    t.boolean 'filled'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'image_url'
+    t.index ['world_id'], name: 'index_gridsquares_on_world_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email"
-    t.text "password_digest"
-    t.text "session_token"
-    t.integer "available_credits"
-    t.string "display_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["display_name"], name: "index_users_on_display_name", unique: true
-    t.index ["session_token"], name: "index_users_on_session_token", unique: true, where: "(session_token IS NOT NULL)"
+  create_table 'users', force: :cascade do |t|
+    t.string 'email'
+    t.text 'password_digest'
+    t.text 'session_token'
+    t.integer 'available_credits'
+    t.string 'display_name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['display_name'], name: 'index_users_on_display_name', unique: true
+    t.index ['session_token'], name: 'index_users_on_session_token', unique: true, where: '(session_token IS NOT NULL)'
   end
 
-  create_table "worlds", force: :cascade do |t|
-    t.string "world_code"
-    t.string "world_name"
-    t.bigint "user_id_id"
-    t.boolean "is_public"
-    t.string "max_player"
-    t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id_id"], name: "index_worlds_on_user_id_id"
+  create_table 'worlds', force: :cascade do |t|
+    t.string 'world_code'
+    t.string 'world_name'
+    t.bigint 'user_id_id'
+    t.boolean 'is_public'
+    t.string 'max_player'
+    t.text 'data'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id_id'], name: 'index_worlds_on_user_id_id'
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "gridsquares", "worlds"
+  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'gridsquares', 'worlds'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_241_126_202_131) do
+ActiveRecord::Schema[7.1].define(version: 20_241_126_202_135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -42,6 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 20_241_126_202_131) do
   create_table 'active_storage_variant_records', force: :cascade do |t|
     t.bigint 'blob_id', null: false
     t.string 'variation_digest', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
     t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
   end
 
@@ -80,7 +82,5 @@ ActiveRecord::Schema[7.1].define(version: 20_241_126_202_131) do
     t.index ['user_id_id'], name: 'index_worlds_on_user_id_id'
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
   add_foreign_key 'gridsquares', 'worlds'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,77 +10,74 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-# rubocop:disable Metrics/BlockLength
-ActiveRecord::Schema[7.1].define(version: 20_241_124_021_748) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_26_202131) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'active_storage_attachments', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
-                                                    unique: true
-  end
-  # rubocop:disable Rails/CreateTableWithTimestamps
-  create_table 'active_storage_blobs', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.string 'service_name', null: false
-    t.bigint 'byte_size', null: false
-    t.string 'checksum'
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_variant_records', force: :cascade do |t|
-    t.bigint 'blob_id', null: false
-    t.string 'variation_digest', null: false
-    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'gridsquares', force: :cascade do |t|
-    t.bigint 'world_id'
-    t.integer 'row'
-    t.integer 'col'
-    t.boolean 'filled'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['world_id'], name: 'index_gridsquares_on_world_id'
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.text 'password_digest'
-    t.text 'session_token'
-    t.integer 'available_credits'
-    t.string 'display_name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['display_name'], name: 'index_users_on_display_name', unique: true
-    t.index ['session_token'], name: 'index_users_on_session_token', unique: true, where: '(session_token IS NOT NULL)'
+  create_table "gridsquares", force: :cascade do |t|
+    t.bigint "world_id"
+    t.integer "row"
+    t.integer "col"
+    t.boolean "filled"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "image_url"
+    t.index ["world_id"], name: "index_gridsquares_on_world_id"
   end
 
-  create_table 'worlds', force: :cascade do |t|
-    t.string 'world_code'
-    t.string 'world_name'
-    t.bigint 'user_id_id'
-    t.boolean 'is_public'
-    t.string 'max_player'
-    t.text 'data'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id_id'], name: 'index_worlds_on_user_id_id'
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.text "password_digest"
+    t.text "session_token"
+    t.integer "available_credits"
+    t.string "display_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_name"], name: "index_users_on_display_name", unique: true
+    t.index ["session_token"], name: "index_users_on_session_token", unique: true, where: "(session_token IS NOT NULL)"
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'gridsquares', 'worlds'
+  create_table "worlds", force: :cascade do |t|
+    t.string "world_code"
+    t.string "world_name"
+    t.bigint "user_id_id"
+    t.boolean "is_public"
+    t.string "max_player"
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id_id"], name: "index_worlds_on_user_id_id"
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "gridsquares", "worlds"
 end
-# rubocop:enable Metrics/BlockLength
-# rubocop:enable Rails/CreateTableWithTimestamps


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Added functions to generate environments and images from OpenAI call. Images are saved to s3 bucket and persist across multiple users accounts on the same world (requires refresh right now but that is expected as movement functionality isn't implemented).

## Related Issue(s)

- Resolves #9 

## Changes

- [x] Added OpenAI text and image generation call
- [x] Added S3 bucket integration

## Screenshots / Demo

<img width="763" alt="Screenshot 2024-11-26 at 4 50 16 PM" src="https://github.com/user-attachments/assets/f4b35674-0272-45f1-8c7d-5a30552ba06d">


## Checklist

- [ ] No linting issues.
- [ ] All tests pass.
- [ ] PR title is descriptive and follows the project’s convention.
