### PR TITLE
concurrent OpenAI API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'coffee-rails'
 
 gem 'terser'
 
+gem 'concurrent-ruby', require: 'concurrent'
+
 gem 'puma'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,6 +440,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails
+  concurrent-ruby
   credit_card_detector
   cucumber-rails
   database_cleaner

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'concurrent'
+
 # WorldController performs basic operations for world generation and state storage.
 class WorldsController < ApplicationController
   before_action :authenticate_user

--- a/app/models/world.rb
+++ b/app/models/world.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'concurrent'
+
 # The world that a user can join, including functions to initialize and
 # update/retrieve information from a displayed grid.
 require 'net/http'
@@ -30,9 +32,10 @@ class World < ApplicationRecord
         gridsquares.create!(row: row, col: col)
       end
     end
-    OpenaiWrapperHelper.create_square(1, 1, self) # only these squares or we get rate limited.
-    OpenaiWrapperHelper.create_square(2, 1, self)
-    OpenaiWrapperHelper.create_square(2, 2, self)
-    OpenaiWrapperHelper.create_square(1, 2, self)
+    # only these squares or we get rate limited.
+    Concurrent::Future.execute { OpenaiWrapperHelper.create_square(1, 1, self) }
+    Concurrent::Future.execute { OpenaiWrapperHelper.create_square(2, 1, self) }
+    Concurrent::Future.execute { OpenaiWrapperHelper.create_square(2, 2, self) }
+    Concurrent::Future.execute { OpenaiWrapperHelper.create_square(1, 2, self) }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,78 +10,73 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-# rubocop:disable Metrics/BlockLength
-ActiveRecord::Schema[7.1].define(version: 20_241_124_021_748) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_24_021748) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'active_storage_attachments', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
-                                                    unique: true
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  # rubocop:disable Rails/CreateTableWithTimestamps
-  create_table 'active_storage_blobs', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.string 'service_name', null: false
-    t.bigint 'byte_size', null: false
-    t.string 'checksum'
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'active_storage_variant_records', force: :cascade do |t|
-    t.bigint 'blob_id', null: false
-    t.string 'variation_digest', null: false
-    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
-  end
-  # rubocop:enable Rails/CreateTableWithTimestamps
-
-  create_table 'gridsquares', force: :cascade do |t|
-    t.bigint 'world_id'
-    t.integer 'row'
-    t.integer 'col'
-    t.boolean 'filled'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['world_id'], name: 'index_gridsquares_on_world_id'
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.text 'password_digest'
-    t.text 'session_token'
-    t.integer 'available_credits', default: 0, null: false
-    t.string 'display_name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['display_name'], name: 'index_users_on_display_name', unique: true
-    t.index ['session_token'], name: 'index_users_on_session_token', unique: true, where: '(session_token IS NOT NULL)'
+  create_table "gridsquares", force: :cascade do |t|
+    t.bigint "world_id"
+    t.integer "row"
+    t.integer "col"
+    t.boolean "filled"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["world_id"], name: "index_gridsquares_on_world_id"
   end
 
-  create_table 'worlds', force: :cascade do |t|
-    t.string 'world_code'
-    t.string 'world_name'
-    t.bigint 'user_id_id'
-    t.boolean 'is_public'
-    t.string 'max_player'
-    t.text 'data'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id_id'], name: 'index_worlds_on_user_id_id'
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.text "password_digest"
+    t.text "session_token"
+    t.integer "available_credits", default: 0, null: false
+    t.string "display_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_name"], name: "index_users_on_display_name", unique: true
+    t.index ["session_token"], name: "index_users_on_session_token", unique: true, where: "(session_token IS NOT NULL)"
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'gridsquares', 'worlds'
+  create_table "worlds", force: :cascade do |t|
+    t.string "world_code"
+    t.string "world_name"
+    t.bigint "user_id_id"
+    t.boolean "is_public"
+    t.string "max_player"
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id_id"], name: "index_worlds_on_user_id_id"
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "gridsquares", "worlds"
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
# 🚀 Pull Request

## Summary
Made all openai calls concurrent

## Related Issue(s)

#9 

## Changes

<!-- List out the main changes made in this PR. -->
- [x] Made all calls to openai concurrent. 
- [x] added the gem for concurrent API calls.

## Testing

<!-- Describe how the changes were tested. -->
We are out of openai credits, I was able to see all of our calls to GPT 3.5 turbo fail because of that after the page was rendered to the client, which gives me faith that it works. We have the code set to do nothing if the calls to GPT fail.

<img width="1342" alt="Screenshot 2024-11-28 at 16 47 33" src="https://github.com/user-attachments/assets/41731b0b-c77c-4a82-aee2-a809e10d0033">


## Screenshots / Demo

<!-- Optional: Add any screenshots or video demos to illustrate the changes. -->

## Checklist

- [x] No linting issues.
- [x] All tests pass.
- [x] PR title is descriptive and follows the project’s convention.

## Additional Notes
Note that the behavior now is that empty grid is rendered to the client, while we have background threads attaching images to the gridcells

## GEMS ADDED 
concurrent-ruby, used to handle concurrent API calls.

