### PR TITLE
Added back purchase plus user button to main worlds page

### DIFF
--- a/app/views/worlds/index.html.erb
+++ b/app/views/worlds/index.html.erb
@@ -28,6 +28,9 @@
         <%= button_to '+', "users/purchase", method: :get, id: "purchase_button", style: "background-color: #A7BCC7;"%>
       </div>
     </div>
+    <div class="left-stack" style="text-align: center; margin: auto">
+      <%= button_to 'Purchase Plus User', users_purchase_plus_user_view_path, method: :get, id: "purchase_plus_user_button", class: "small_button highlight_button" %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Added missing purchase plus button back to worlds page.

## Testing

- [ ] Unit tests passed.

## Screenshots / Demo

<img width="1710" alt="Screenshot 2024-11-30 at 2 28 38 PM" src="https://github.com/user-attachments/assets/0668719a-086d-4c26-bbfd-9c6cad502342">


## Checklist

- [ ] No linting issues.
- [ ] All tests pass.
- [ ] PR title is descriptive and follows the project’s convention.

